### PR TITLE
Added support for vertical splitting

### DIFF
--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -69,10 +69,8 @@ function! s:OpenWinAndStay()
 
         execute 'silent keepalt topleft '.ksplit.' '.s:buf_name
 
-        if exists('g:todo_vertical')
-          if exists('g:todo_right')
-            execute 'wincmd L'
-          endif
+        if exists('g:todo_vertical') && exists('g:todo_right') 
+          execute 'wincmd L'
         endif
 
         call s:InitWindow()

--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -63,11 +63,12 @@ endfunction
 function! s:OpenWinAndStay()
     let todowinnr = bufwinnr(s:buf_name)
     let pos = exists('g:todo_winposition') ? g:todo_winposition : 'topleft'
+    let split = exists('g:todo_isvertical') ? 'vsplit' : 'split'
 
     if todowinnr == -1
         call s:ToDoUpdate()
 
-        execute 'silent keepalt '.pos.' split '.s:buf_name
+        execute 'silent keepalt '.pos.' '.split.' '.s:buf_name
 
         call s:InitWindow()
         call s:UpdateWindow()

--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -45,6 +45,10 @@ function! s:InitWindow() abort
         execute 'resize ' . g:todo_winheight . '<CR>'
     endif
 
+    if exists('g:todo_winwidth')
+      execute 'vertical resize ' . g:todo_winwidth . '<CR>'
+    endif
+
 endfunction
 
 function! s:OpenWindow()
@@ -58,11 +62,12 @@ endfunction
 
 function! s:OpenWinAndStay()
     let todowinnr = bufwinnr(s:buf_name)
+    let pos = exists('g:todo_winposition') ? g:todo_winposition : 'topleft'
 
     if todowinnr == -1
         call s:ToDoUpdate()
 
-        execute 'silent keepalt topleft split '.s:buf_name
+        execute 'silent keepalt '.pos.' split '.s:buf_name
 
         call s:InitWindow()
         call s:UpdateWindow()

--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -62,13 +62,18 @@ endfunction
 
 function! s:OpenWinAndStay()
     let todowinnr = bufwinnr(s:buf_name)
-    let pos = exists('g:todo_winposition') ? g:todo_winposition : 'topleft'
-    let ksplit = exists('g:todo_isvertical') ? 'vsplit' : 'split'
+    let ksplit = exists('g:todo_vertical') ? 'vsplit' : 'split'
 
     if todowinnr == -1
         call s:ToDoUpdate()
 
-        execute 'silent keepalt '.pos.' '.ksplit.' '.s:buf_name
+        execute 'silent keepalt topleft '.ksplit.' '.s:buf_name
+
+        if exists('g:todo_vertical')
+          if exists('g:todo_right')
+            execute 'wincmd L'
+          endif
+        endif
 
         call s:InitWindow()
         call s:UpdateWindow()

--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -46,7 +46,6 @@ function! s:InitWindow() abort
     endif
 
     if exists('g:todo_winwidth')
-      echom g:todo_winwidth
       execute 'vertical resize ' . g:todo_winwidth . '<CR>'
     endif
 

--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -46,6 +46,7 @@ function! s:InitWindow() abort
     endif
 
     if exists('g:todo_winwidth')
+      echom g:todo_winwidth
       execute 'vertical resize ' . g:todo_winwidth . '<CR>'
     endif
 
@@ -109,7 +110,7 @@ function! s:UpdateWindow()
     execute "normal! ggdG"
 
     if len(s:todo_info) == 0
-        silent 0put ='\" Nothing yet('
+        silent 0put ='\" Nothing yet'
     else
         silent 0put ='\" Press ? for help'
         silent put _

--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -63,12 +63,12 @@ endfunction
 function! s:OpenWinAndStay()
     let todowinnr = bufwinnr(s:buf_name)
     let pos = exists('g:todo_winposition') ? g:todo_winposition : 'topleft'
-    let split = exists('g:todo_isvertical') ? 'vsplit' : 'split'
+    let ksplit = exists('g:todo_isvertical') ? 'vsplit' : 'split'
 
     if todowinnr == -1
         call s:ToDoUpdate()
 
-        execute 'silent keepalt '.pos.' '.split.' '.s:buf_name
+        execute 'silent keepalt '.pos.' '.ksplit.' '.s:buf_name
 
         call s:InitWindow()
         call s:UpdateWindow()

--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -45,6 +45,10 @@ function! s:InitWindow() abort
         execute 'resize ' . g:todo_winheight . '<CR>'
     endif
 
+    if exists('g:todo_vertical') && exists('g:todo_right') 
+      execute 'wincmd L'
+    endif
+
     if exists('g:todo_winwidth')
       execute 'vertical resize ' . g:todo_winwidth . '<CR>'
     endif
@@ -68,10 +72,6 @@ function! s:OpenWinAndStay()
         call s:ToDoUpdate()
 
         execute 'silent keepalt topleft '.ksplit.' '.s:buf_name
-
-        if exists('g:todo_vertical') && exists('g:todo_right') 
-          execute 'wincmd L'
-        endif
 
         call s:InitWindow()
         call s:UpdateWindow()

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -48,7 +48,7 @@ After installation you can run todo-vim with the |:TODOOpen| or |:TODOToggle|
 commands.
 
 ==============================================================================
-4. Usage                                                          *todo-usage*
+3. Usage                                                          *todo-usage*
 
 Basic usage of todo-vim is opening todo window by |:TODOOpen| and moving
 the cursor to a certain label. If set of g:todo_autopreview variable, you
@@ -111,6 +111,18 @@ g:todo_winheight                                            *g:todo_winheight*
        If you do not like the standard height of the window, use this
        variable. The value of this variable is the height of the window when
        opening.
+
+g:todo_winwidth                                              *g:todo_winwidth*
+       Use this variable to change the vertical size (aka the width) of the
+       todo window.
+
+g:todo_vertical                                              *g:todo_vertical*
+       When this variable is set to 1, the todo window will be launched in a
+       vertical mode, and not in an horizontal mode.
+
+g:todo_right                                                    *g:todo_right*
+       When this variable and the *g:todo_vertical* are set to 1 the vertical
+       window will be launched on the right and not on the left.
 
 ==============================================================================
 4. Tags                                                          *todo-tags*


### PR DESCRIPTION
I really liked the plugin and wanted to use it in a vertical split and not in a regular split like the default way it works, so I've added support through these global variables:

```vim
let g:todo_vertical = 1 " Enabling the vertical splitting
let g:todo_right = 1 " Positioning the window on the right side of the editor
let g:todo_winiwdth = 30 " Setting the width of the vertical window
```