### PR TITLE
Below option

### DIFF
--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -41,7 +41,7 @@ function! s:InitWindow() abort
 
     call s:MappingKeys()
 
-    if exists('g:todo_below')
+    if exists('g:todo_below') && !exists('g:todo_vertical')
       execute 'wincmd J'
     endif
 

--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -41,16 +41,16 @@ function! s:InitWindow() abort
 
     call s:MappingKeys()
 
+    if exists('g:todo_below')
+      execute 'wincmd J'
+    endif
+
     if exists('g:todo_winheight')
         execute 'resize ' . g:todo_winheight . '<CR>'
     endif
 
     if exists('g:todo_vertical') && exists('g:todo_right') 
       execute 'wincmd L'
-    endif
-
-    if exists('g:todo_below')
-      execute 'wincmd J'
     endif
 
     if exists('g:todo_winwidth')

--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -49,6 +49,10 @@ function! s:InitWindow() abort
       execute 'wincmd L'
     endif
 
+    if exists('g:todo_below')
+      execute 'wincmd J'
+    endif
+
     if exists('g:todo_winwidth')
       execute 'vertical resize ' . g:todo_winwidth . '<CR>'
     endif

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -124,6 +124,11 @@ g:todo_right                                                    *g:todo_right*
        When this variable and the todo_vertical are set to 1 the vertical
        window will be launched on the right and not on the left.
 
+g:todo_below                                                    *g:todo_below*
+       When this variable is set to 1, the todo window will be launched on
+       the bottom and not on the top. This flag only takes effect if
+       |g:todo_vertical| is not set.
+
 ==============================================================================
 4. Tags                                                          *todo-tags*
 


### PR DESCRIPTION
Added the option 'g:todo_below' to allow the user the have the todo list below their current window. The flag takes no effect if the split is set to be vertical.