### PR TITLE
Add support for the XXX todo tag

### DIFF
--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -2,8 +2,11 @@ let g:loaded_todo = 1
 
 let s:buf_name        = '__todo__'
 let s:todo_info       = []
-let s:todo_type       = ['todo', 'fixme', 'note']
-let s:todo_patterns   = ["TODO[^a-zA-Z]", "FIXME[^a-zA-Z]", "NOTE[^a-zA-Z]"]
+let s:todo_type       = ['todo', 'fixme', 'note', 'xxx']
+let s:todo_patterns   = ["TODO[^a-zA-Z]",
+                        \"FIXME[^a-zA-Z]",
+                        \"NOTE[^a-zA-Z]",
+                        \"XXX[^a-zA-Z]"]
 let s:tag_arg_pattern = '\v\:(\"[^\"]+\"|[^\ ]+)'
 let s:tag_pattern     = '\v\@[^\ ]+(\ ' . strpart(s:tag_arg_pattern, 2) . ')?'
 let s:sort_comp       = 's:LineComparator' " Default sort labels by line
@@ -49,7 +52,7 @@ function! s:InitWindow() abort
         execute 'resize ' . g:todo_winheight . '<CR>'
     endif
 
-    if exists('g:todo_vertical') && exists('g:todo_right') 
+    if exists('g:todo_vertical') && exists('g:todo_right')
       execute 'wincmd L'
     endif
 

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -19,9 +19,9 @@ Contents                                                       *todo-contents*
 ==============================================================================
 1. Intro                                                          *todo-intro*
 
-todo-vim is plugin for manage your todo notes. He will help you to navigate 
+todo-vim is plugin for manage your todo notes. He will help you to navigate
 and manage your todo labels in code. Plugin support next type of labels: todo,
-fixme, note. Label examples:
+fixme, note, xxx. Label examples:
 
 TODO: Simple todo example
 TODO: todo with tag priority and custom tag @p :8 @custom :custom


### PR DESCRIPTION
Vim and Neovim list `TODO`,`FIXME`, and `XXX`
as part of the Todo highlight group. Here is an excerpt
from the documtentation (`:h group-name<CR>`):

```
NAMING CONVENTIONS		    *group-name* *{group-name}* *E669* *W18*

A syntax group name is to be used for syntax items that match the same kind of
thing.  These are then linked to a highlight group that specifies the color.
A syntax group name doesn't specify any color or attributes itself.

The name for a highlight or syntax group must consist of ASCII letters, digits
and the underscore.  As a regexp: "[a-zA-Z0-9_]*".  However, Vim does not give
an error when using other characters.

To be able to allow each user to pick his favorite set of colors, there must
be preferred names for highlight groups that are common for many languages.
These are the suggested group names (if syntax highlighting works properly
you can see the actual color, except for "Ignore"):

	*Comment	any comment

	*Constant	any constant
	 String		a string constant: "this is a string"
	 Character	a character constant: 'c', '\n'
	 Number		a number constant: 234, 0xff
	 Boolean	a boolean constant: TRUE, false
	 Float		a floating point constant: 2.3e10

	*Identifier	any variable name
	 Function	function name (also: methods for classes)

	*Statement	any statement
	 Conditional	if, then, else, endif, switch, etc.
	 Repeat		for, do, while, etc.
	 Label		case, default, etc.
	 Operator	"sizeof", "+", "*", etc.
	 Keyword	any other keyword
	 Exception	try, catch, throw

	*PreProc	generic Preprocessor
	 Include	preprocessor #include
	 Define		preprocessor #define
	 Macro		same as Define
	 PreCondit	preprocessor #if, #else, #endif, etc.

	*Type		int, long, char, etc.
	 StorageClass	static, register, volatile, etc.
	 Structure	struct, union, enum, etc.
	 Typedef	A typedef

	*Special	any special symbol
	 SpecialChar	special character in a constant
	 Tag		you can use CTRL-] on this
	 Delimiter	character that needs attention
	 SpecialComment	special things inside a comment
	 Debug		debugging statements

	*Underlined	text that stands out, HTML links

	*Ignore		left blank, hidden  |hl-Ignore|

	*Error		any erroneous construct

	*Todo		anything that needs extra attention; mostly the
			keywords TODO FIXME and XXX

The names marked with * are the preferred groups; the others are minor groups.
For the preferred groups, the "syntax.vim" file contains default highlighting.
The minor groups are linked to the preferred groups, so they get the same
highlighting.  You can override these defaults by using ":highlight" commands
after sourcing the "syntax.vim" file.
```

It could therefore be useful to be consistent with what vim currently offers.
